### PR TITLE
Allow participants to join a room with a custom name

### DIFF
--- a/src/org/jitsi/meet/test/ConferenceFixture.java
+++ b/src/org/jitsi/meet/test/ConferenceFixture.java
@@ -713,7 +713,10 @@ public class ConferenceFixture
     }
     
     /**
-     *
+     * Starts the participant reusing the already generated room name.
+     * @param frament A string to be added to the URL as a parameter (i.e.
+     * prefixed with a '&').
+     * @return the {@code WebDriver} which was started.
      */
      public static WebDriver startParticipant(String fragment)
      {
@@ -721,7 +724,7 @@ public class ConferenceFixture
      }
 
     /**
-     * Starts the participant reusing the already generated room name.
+     * Starts the participant with a parameter, if given.
      * Checks if instance is created do not create it again, if its just not in
      * the room just join there.
      * @param fragment A string to be added to the URL as a parameter (i.e.

--- a/src/org/jitsi/meet/test/ConferenceFixture.java
+++ b/src/org/jitsi/meet/test/ConferenceFixture.java
@@ -713,17 +713,27 @@ public class ConferenceFixture
     }
     
     /**
+     *
+     */
+     public static WebDriver startParticipant(String fragment)
+     {
+         return startParticipant(fragment, null);
+     }
+
+    /**
      * Starts the participant reusing the already generated room name.
      * Checks if instance is created do not create it again, if its just not in
      * the room just join there.
      * @param fragment A string to be added to the URL as a parameter (i.e.
      * prefixed with a '&').
+     * @param roomParameter Extra parameter to add on to the generated room name
      * @return the {@code WebDriver} which was started.
      * NOTE: Uses the browser type set for the owner.
      */
-    public static WebDriver startParticipant(String fragment)
+    public static WebDriver startParticipant(String fragment, String roomParameter)
     {
         System.err.println("Starting participant");
+        String roomName = currentRoomName;
 
         BrowserType browser
             = BrowserType.valueOfString(
@@ -732,7 +742,10 @@ public class ConferenceFixture
         WebDriver participant = 
             startDriver(browser, Participant.otherParticipantDriver);
 
-        openRoom(participant, currentRoomName, fragment, browser);
+        if (roomParameter != null)
+            roomName += roomParameter;
+
+        openRoom(participant, roomName, fragment, browser);
 
         ((JavascriptExecutor) participant)
             .executeScript("document.title='Participant'");

--- a/src/org/jitsi/meet/test/ConferenceFixture.java
+++ b/src/org/jitsi/meet/test/ConferenceFixture.java
@@ -265,21 +265,41 @@ public class ConferenceFixture
      */
     public static WebDriver startOwner(String fragment)
     {
+        return startOwner(fragment, null);
+    }
+
+    /**
+     * Initializes <tt>currentRoomName</tt> and starts the "owner".
+     * @param fragment fragment to be added the URL opened by the "owner".
+     * @param roomParameter an extra parameter to the url. The fragment adds
+     * parameters as # where roomParameter actually changes query parameters
+     * adding ?something=value.
+     * @return the {@code WebDriver} which was started.
+     */
+    public static WebDriver startOwner(String fragment, String roomParameter)
+    {
         System.err.println("Starting owner participant.");
 
         BrowserType browser
             = BrowserType.valueOfString(System.getProperty(
                     BROWSER_OWNER_NAME_PROP));
 
-        if(owner == null)
+        String roomName = currentRoomName;
+        if(owner == null || roomParameter!= null)
         {
-            currentRoomName = "torture"
+            roomName = currentRoomName = "torture"
                 + String.valueOf((int)(Math.random()*1000000));
 
-            owner = startDriver(browser, Participant.ownerDriver);
+            // we do not persist room params for now, in case of jwt
+            // we want them just for one of the participants
+            if (roomParameter != null)
+                roomName += roomParameter;
+
+            if (owner == null)
+                owner = startDriver(browser, Participant.ownerDriver);
         }
 
-        openRoom(owner, fragment, browser);
+        openRoom(owner, roomName, fragment, browser);
 
         ownerHungUp = false;
 
@@ -293,16 +313,17 @@ public class ConferenceFixture
      * Opens the room for the given participant.
      *
      * @param participant to open the current test room.
+     * @param roomName the room name to join
      * @param fragment adds the given string to the fragment part of the URL
      * @param browser the browser type.
      */
     public static void openRoom(
             WebDriver participant,
+            String roomName,
             String fragment,
             BrowserType browser)
     {
-        String URL = System.getProperty(JITSI_MEET_URL_PROP) + "/"
-            + currentRoomName;
+        String URL = System.getProperty(JITSI_MEET_URL_PROP) + "/" + roomName;
         URL += "#config.requireDisplayName=false";
         URL += "&config.debug=true";
         URL += "&config.disableAEC=true";
@@ -642,7 +663,7 @@ public class ConferenceFixture
             secondParticipant
                 = startDriver(browser, Participant.secondParticipantDriver);
 
-        openRoom(secondParticipant, fragment, browser);
+        openRoom(secondParticipant, currentRoomName, fragment, browser);
 
         secondParticipantHungUp = false;
 
@@ -681,7 +702,7 @@ public class ConferenceFixture
             thirdParticipant
                 = startDriver(browser, Participant.thirdParticipantDriver);
 
-        openRoom(thirdParticipant, fragment, browser);
+        openRoom(thirdParticipant, currentRoomName, fragment, browser);
 
         thirdParticipantHungUp = false;
 
@@ -711,7 +732,7 @@ public class ConferenceFixture
         WebDriver participant = 
             startDriver(browser, Participant.otherParticipantDriver);
 
-        openRoom(participant, fragment, browser);
+        openRoom(participant, currentRoomName, fragment, browser);
 
         ((JavascriptExecutor) participant)
             .executeScript("document.title='Participant'");

--- a/src/org/jitsi/meet/test/MaxUsersTest.java
+++ b/src/org/jitsi/meet/test/MaxUsersTest.java
@@ -86,46 +86,38 @@ public class MaxUsersTest
         {
             MAX_USERS = Integer.parseInt(maxUsersString);
         }
-            
-        if(MAX_USERS > 1)
-        {
-            boolean failed = false;
-            // Assuming we have 1 participant already started we have to
-            // start MAX_USERS - 1 participants more to have MAX_USERS
-            // participants in the call in order to exceed the limit.
-            WebDriver[] participants = new WebDriver[MAX_USERS - 1];
-            try
-            {
-                for(int i = 0; i < participants.length; i++)
-                {
-                    // Participants join the custom room created by the owner
-                    participants[i] = ConferenceFixture.startParticipant(null, roomName);
-                }
-                // Check if the error dialog is displayed for
-                // the last participant.
-                int lastParticipantIdx = participants.length - 1;
-                checkDialog(participants[lastParticipantIdx]);
-            } 
-            catch(TimeoutException timeout)
-            {
-                // There was no dialog, so we fail the test !
-                failed = true;
-            }
-            finally
-            {
-                // Clean up the participants in participants array
-                quitParticipants(participants);
-                ConferenceFixture.restartParticipants();
-            }
 
-            if (failed)
-            {
-                fail("There was no error dialog.");
-            }
-        }
-        else
+        boolean failed = false;
+
+        // The owner has already been started, so MAX - 1 users are needed to hit the 
+        // occupant limit of the room
+        WebDriver[] participants = new WebDriver[MAX_USERS - 1];
+        try
         {
-            checkDialog(ConferenceFixture.getSecondParticipant());
+            for(int i = 0; i < participants.length; i++)
+            {
+                // Participants join the custom room created by the owner
+                participants[i] = ConferenceFixture.startParticipant(null, roomName);
+            }
+            // Check if the error dialog is displayed for the last participant.
+            int lastParticipantIdx = participants.length - 1;
+            checkDialog(participants[lastParticipantIdx]);
+        } 
+        catch(TimeoutException timeout)
+        {
+            // There was no dialog, so we fail the test !
+            failed = true;
+        }
+        finally
+        {
+            // Clean up the participants in participants array
+            quitParticipants(participants);
+            ConferenceFixture.restartParticipants();
+        }
+
+        if (failed)
+        {
+            fail("There was no error dialog.");
         }
     }
 

--- a/src/org/jitsi/meet/test/MaxUsersTest.java
+++ b/src/org/jitsi/meet/test/MaxUsersTest.java
@@ -115,6 +115,7 @@ public class MaxUsersTest
             {
                 // Clean up the participants in participants array
                 quitParticipants(participants);
+                ConferenceFixture.restartParticipants();
             }
 
             if (failed)

--- a/src/org/jitsi/meet/test/MaxUsersTest.java
+++ b/src/org/jitsi/meet/test/MaxUsersTest.java
@@ -75,8 +75,9 @@ public class MaxUsersTest
         String roomName = "MaxUsersTortureTest";
 
         // Exit all participants
-        ConferenceFixture.closeAllParticipants();
-
+        ConferenceFixture.close(ConferenceFixture.getOwnerInstance());
+        ConferenceFixture.quit(ConferenceFixture.getSecondParticipant());
+        
         // Start owner with custom roomname used to set the max occupants by prosody
         WebDriver owner = ConferenceFixture.startOwner(null, roomName);
 

--- a/src/org/jitsi/meet/test/MaxUsersTest.java
+++ b/src/org/jitsi/meet/test/MaxUsersTest.java
@@ -72,12 +72,13 @@ public class MaxUsersTest
      */
     public void enterWithMaxParticipantsAndCheckDialog() 
     {
+        String roomName = "MaxUsersTortureTest";
+
         // Exit all participants
         ConferenceFixture.closeAllParticipants();
 
         // Start owner with custom roomname used to set the max occupants by prosody
-        WebDriver owner = ConferenceFixture.startOwner("", "MaxUsersTortureTest");
-        ConferenceFixture.waitForSecondParticipantToConnect();
+        WebDriver owner = ConferenceFixture.startOwner(null, roomName);
 
         String maxUsersString = System.getProperty(MAX_USERS_PROP);
         if(maxUsersString != null)
@@ -85,18 +86,19 @@ public class MaxUsersTest
             MAX_USERS = Integer.parseInt(maxUsersString);
         }
             
-        if(MAX_USERS > 2)
+        if(MAX_USERS > 1)
         {
             boolean failed = false;
-            // Assuming we have 2 participants already started we have to
-            // start MAX_USERS - 2 participants more to have MAX_USERS
+            // Assuming we have 1 participant already started we have to
+            // start MAX_USERS - 1 participants more to have MAX_USERS
             // participants in the call in order to exceed the limit.
-            WebDriver[] participants = new WebDriver[MAX_USERS - 2];
+            WebDriver[] participants = new WebDriver[MAX_USERS - 1];
             try
             {
                 for(int i = 0; i < participants.length; i++)
                 {
-                    participants[i] = ConferenceFixture.startParticipant(null);
+                    // Participants join the custom room created by the owner
+                    participants[i] = ConferenceFixture.startParticipant(null, roomName);
                 }
                 // Check if the error dialog is displayed for
                 // the last participant.

--- a/src/org/jitsi/meet/test/MaxUsersTest.java
+++ b/src/org/jitsi/meet/test/MaxUsersTest.java
@@ -72,6 +72,13 @@ public class MaxUsersTest
      */
     public void enterWithMaxParticipantsAndCheckDialog() 
     {
+        // Exit all participants
+        ConferenceFixture.closeAllParticipants();
+
+        // Start owner with custom roomname used to set the max occupants by prosody
+        WebDriver owner = ConferenceFixture.startOwner("", "MaxUsersTortureTest");
+        ConferenceFixture.waitForSecondParticipantToConnect();
+
         String maxUsersString = System.getProperty(MAX_USERS_PROP);
         if(maxUsersString != null)
         {


### PR DESCRIPTION
Some changes were made on the Jitsi side to allow rooms to be created with a custom parameter (which can be used to customize the name of the room). To make the max occupants tests work, allow participants to join rooms created with a custom parameter.